### PR TITLE
Fixing crashing bug on form plus tiny tweak to styling

### DIFF
--- a/client/src/components/reservations/ReservationForm.js
+++ b/client/src/components/reservations/ReservationForm.js
@@ -11,7 +11,7 @@ class ReservationForm extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            customer: "1",
+            customer: "",
             venueTable: "",
             start: moment().format().slice(0, 16),
             end: "",
@@ -76,9 +76,8 @@ class ReservationForm extends Component {
     }
 
     selectCustomerById(id) {
-        const selectedCustomer = this.getCustomerById(id);
         this.setState({
-            customer: selectedCustomer
+            customer: `${id}`
         });
     }
 
@@ -120,11 +119,14 @@ class ReservationForm extends Component {
         this.setState({
             customer: "",
             venueTable: "",
-            start: "",
+            start: moment().format().slice(0, 16),
             end: "",
-            partySize: 1,
-            reservationNotes: ""
-        });
+            partySize: "",
+            duration: "2",
+            reservationNotes: "",
+            availableTables: [],
+            showModal: false
+        }, () => this.updateEnd());
     }
 
     updateEnd() {
@@ -241,7 +243,11 @@ class ReservationForm extends Component {
                                         name="customer"
                                         value={this.state.customer}
                                         onChange={this.handleCustomerSelect}
-                                    >{customerOptions}</select>
+                                        required
+                                    >
+                                        <option value="" disabled>Please Select</option>
+                                        {customerOptions}
+                                    </select>
                                     <button onClick={this.handleOpenModal}>New</button>
                                     </td>
                                 </tr>
@@ -252,7 +258,11 @@ class ReservationForm extends Component {
                                         name="venue-table"
                                         value={this.state.venueTable}
                                         onChange={this.handleVenueTableSelect}
-                                    >{venueTableOptions}</select></td>
+                                        required
+                                    >   
+                                        <option value="" disabled>Please Select</option>
+                                        {venueTableOptions}
+                                    </select></td>
                                 </tr>
 
                                 <tr>

--- a/client/src/styles/ReservationForm.css
+++ b/client/src/styles/ReservationForm.css
@@ -18,7 +18,7 @@ th, td, h2 {
 }
 
 th {
-  text-align: rigt;
+  text-align: right;
 }
 
 input, select, button {
@@ -38,6 +38,10 @@ input[type="submit"], button {
 
 input[type="submit"]:hover, button:hover {
   box-shadow: 1px 1px var(--shadow);
+}
+
+select {
+  width: 150px;
 }
 
 .modal {


### PR DESCRIPTION
Issue was that the form looked filled in but wasn't really (when you looked in the dev tools).  This caused the app to crash when you were unsuccessful in adding a reservation, but tried to view it in the list (the error was shoved in there).  Fixed this by making both customer and venue table drop downs required fields and adding default "Please Select" options...